### PR TITLE
FEAT : 여러 입력프롬프트 입력, 로딩추가, api인코딩변경

### DIFF
--- a/final-project/src/pages/Generatepage.jsx
+++ b/final-project/src/pages/Generatepage.jsx
@@ -8,17 +8,27 @@ import Prompts from '../features/generate/components/Prompts'
 import BoxItem from '../features/ui/BoxItem/BoxItem'
 import axios from 'axios'
 import ColorButton from '../features/ui/button/ColorButton/ColorButton';
+import BarLoader from 'react-spinners/BarLoader'
 const Generatepage = () => {
-const [image, updateImage] = useState()
+const [image, updateImage] = useState([])
+const [loading, setLoading] = useState();
 const promptsList = useSelector((state) => state.cur_project.prompts);
+const pormptsNum = useSelector((state) => state.cur_project.imgNums);
 
-  const generate = async (prompt) => {
-    const result = await axios.get(
-      `http://64.98.238.3:41006/?prompt==${prompt}`
-    );
-    console.log(result);
-    updateImage(result.data);
+  const generate = async ({ prompt, promptLen }) => {
+    updateImage([])
+    setLoading(true)
+    for (let i = 0; i < promptLen; i++) {
+      const result = await axios.get(
+        `http://184.145.163.125:41226/?prompt==${prompt[i]},%20pencil%20sketch,%20cartoon%20storyboard,%20fast%20sketch,%20gray%20color`
+      );
+      image.push(result.data);
+      updateImage([...image]);
+    }
+    setLoading(false)
   };
+
+  console.log(loading);
 
   return (
     <div className={styles.Wrapper}>
@@ -30,14 +40,30 @@ const promptsList = useSelector((state) => state.cur_project.prompts);
           <ToggleBtn tab1={"생성"} tab2={"편집"} />
           <BoxItem title={"생성할 컷 수 지정"} />
           <CutsNumber />
-          <BoxItem title={'콘티 내용 입력'} />
+          <BoxItem title={"콘티 내용 입력"} />
           <div className={styles.promptsBox}>
             <Prompts />
           </div>
-          <ColorButton text={'생성하기'} func={generate} parameter={promptsList[0]}/>
+          <ColorButton text={"생성하기"} func={generate} parameter={{ prompt: promptsList, promptLen: pormptsNum }}/>
         </section>
         <section className={styles.canvas}>
-          {image? <img src={`data:image/png;base64,${image}`} alt="표시" /> : null}
+          {loading ?
+          <div className={styles.loading_bar}>
+            <BarLoader color="#36d7b7" loading={loading} width={200} height={20}/>
+          </div>
+          : image ?
+            image.map((img, idx) => {
+              return (
+                <img
+                  key={`img-${idx}`}
+                  className={styles.images}
+                  src={`data:image/png;base64,${img}`}
+                  alt="표시"
+                />
+              );
+            })
+          : null
+          }
         </section>
         <section className={styles.designTab}></section>
       </div>

--- a/final-project/src/pages/Generatepage.module.scss
+++ b/final-project/src/pages/Generatepage.module.scss
@@ -40,3 +40,14 @@
     height: 30vh;
     overflow-y: scroll;
 }
+
+.images {
+    width: 256px;
+    height: 256px;
+}
+
+.loading_bar {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/modelAPI/api.py
+++ b/modelAPI/api.py
@@ -32,6 +32,7 @@ def generate(prompt: str):
     image.save("testimage.png")
     buffer = BytesIO()
     image.save(buffer, format="PNG")
-    imgstr = base64.b16encode(buffer.getvalue())
+    imgstr = base64.b64encode(buffer.getvalue())
+    result = imgstr.decode('ascii')
 
-    return Response(content=imgstr, media_type="image/png")
+    return Response(content=result, media_type="text/plain")


### PR DESCRIPTION
- api 인코딩 방법 변경
- Generate.jsx 에서 image업데이트를 배열로 하도록 변경
- promptList[0]에서 promptList자체를 generate 함수에 매개변수로 넣고, 그 이미지 갯수도 매개변수로 넣게 객체로 합쳐서 넣도록 변경
- loading useState 추가
- 삼항 연산자와 map으로 이미지가 안나타나면 로딩이 뜨고 요청이 다 완료되면 이미지가 뜨도록 함
- react-spinners 라이브러리 추가
- 이미지 크기 css 변경, 로딩 css 추가